### PR TITLE
Changed bl_category from "Proxy & Cache" to just "Proxy"

### DIFF
--- a/VSE_Easy_Proxy.py
+++ b/VSE_Easy_Proxy.py
@@ -370,7 +370,7 @@ class SequencerButtonsPanel:
 
 class SEQUENCER_PT_easy_proxy_settings(SequencerButtonsPanel, Panel):
     bl_label = "Easy Proxy Settings"
-    bl_category = "Proxy & Cache"
+    bl_category = "Proxy"
 
     @classmethod
     def poll(cls, context):


### PR DESCRIPTION
Newer versions of blender split the old "Proxy & Cache" tab into separate "Proxy" and "Cache" tabs. Installing this add-on as-is in Blender 3.0 creates a 3rd tab named "Proxy & Cache".

For simplicity sake, I've moved this add-on into the "Proxy" category/tab so that it behaves more consistently like it used to.